### PR TITLE
readme: Remove references to .q TLD

### DIFF
--- a/test/haproxy-test.js
+++ b/test/haproxy-test.js
@@ -42,12 +42,12 @@ frontend http-in
 backend domainA
     balance roundrobin
     cookie SERVERID insert indirect nocache
-    server foo.q foo.q:80 check resolvers dns cookie foo.q
+    server foo foo:80 check resolvers dns cookie foo
 
 backend domainB
     balance roundrobin
     cookie SERVERID insert indirect nocache
-    server bar.q bar.q:80 check resolvers dns cookie bar.q
+    server bar bar:80 check resolvers dns cookie bar
 `;
 
       const domainA = [new kelda.Container('foo', 'image')];


### PR DESCRIPTION
The TLD is going to be removed in the next release of Kelda.