### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ HAProxy will communicate with the services behind it on port 80.
 ```javascript
 const webAContainers = [];
 for (let i = 0; i < 3; i += 1) {
-  webAContainers.push(new Container('webA', 'nginx'));
+  webAContainers.push(new Container({ name: 'webA', image: 'nginx' }));
 }
 
 const webBContainers = [];
 for (let i = 0; i < 2; i += 1) {
-  webBContainers.push(new Container('webB', 'nginx'));
+  webBContainers.push(new Container({ name: 'webB', image: 'nginx' }));
 }
 
 const emailAddress = 'you@example.com';
@@ -57,8 +57,8 @@ HAProxy IP address will be forwarded to the correct web server as determined by 
 `Host` header in the HTTP request. An HTTPS certificate for both domains will be
 automatically requested from Let's Encrypt and installed.
 
-All domains need to be pointing at the floating IP address assigned to the 
-proxy. 
+All domains need to be pointing at the floating IP address assigned to the
+proxy.
 
 ## Accessing the Proxy
 To make the proxy accessible from the public internet, simply add the following

--- a/examples/haproxyHttpsExample.js
+++ b/examples/haproxyHttpsExample.js
@@ -12,7 +12,9 @@ const indexPath = '/usr/share/nginx/html/index.html';
 function appWithContent(numServers, text) {
   const appContainers = [];
   for (let i = 0; i < numServers; i += 1) {
-    appContainers.push(new kelda.Container('web', 'nginx', {
+    appContainers.push(new kelda.Container({
+      name: 'web',
+      image: 'nginx',
       filepathToContent: { [indexPath]: text },
     }));
   }

--- a/haproxyAutoHttps.js
+++ b/haproxyAutoHttps.js
@@ -50,7 +50,9 @@ ${backendConfig}
  * @return {Container} The new HAProxy container.
  */
 function createHapContainer(containers, files, env) {
-  const haproxy = new Container('haproxy', image, {
+  const haproxy = new Container({
+    name: 'haproxy',
+    image,
     env,
     filepathToContent: files,
   });

--- a/test/haproxy-test.js
+++ b/test/haproxy-test.js
@@ -50,8 +50,8 @@ backend domainB
     server bar.q bar.q:80 check resolvers dns cookie bar.q
 `;
 
-      const domainA = [new kelda.Container('foo', 'image')];
-      const domainB = [new kelda.Container('bar', 'image')];
+      const domainA = [new kelda.Container({ name: 'foo', image: 'image' })];
+      const domainB = [new kelda.Container({ name: 'bar', image: 'image' })];
       const email = 'test@example.com';
       const hap = haproxy.create({ domainA, domainB }, email);
       assert.equal(hap.filepathToContent['/usr/local/etc/haproxy/haproxy.cfg'],

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,7 +1,10 @@
 // This file contains the base infrastructure used for the travis build.
 function infraGetter(kelda) {
   const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
-  const infra = new kelda.Infrastructure(vmTemplate, vmTemplate.replicate(2));
+  const infra = new kelda.Infrastructure({
+    masters: vmTemplate,
+    workers: vmTemplate.replicate(2),
+  });
   return infra;
 }
 


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.